### PR TITLE
15 define public api for getting sensor data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /ph-sensor/target/
 /ph-sensor/Cargo.lock
+
+.idea

--- a/ph-sensor/Cargo.toml
+++ b/ph-sensor/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 
 [dependencies]
 threadpool = "1.8.1"
+serde = { version = "1.0.197", features = ["derive"] }
+ctrlc = "3.4.2"

--- a/ph-sensor/Cargo.toml
+++ b/ph-sensor/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 threadpool = "1.8.1"
 serde = { version = "1.0.197", features = ["derive"] }
 ctrlc = "3.4.2"
+serde_json = "1.0.114"

--- a/ph-sensor/src/main.rs
+++ b/ph-sensor/src/main.rs
@@ -32,7 +32,6 @@ fn main() {
     ctrlc::set_handler(move || {
         println!("\nCtrl-C received, stopping threads");
         stop_signal_clone.store(true, Ordering::Relaxed);
-        return;
     })
     .expect("Error setting Ctrl-C handler");
 

--- a/ph-sensor/src/main.rs
+++ b/ph-sensor/src/main.rs
@@ -130,7 +130,7 @@ fn handle_client(
     println!("Request: {:#?}", http_request);
 
     // Request an updated reading from pH sensor thread
-    tx_reading_request.send(true);
+    tx_reading_request.send(true).unwrap();
 
     // Format to JSON
     let reading = rx_ph_value.recv().unwrap();
@@ -172,8 +172,8 @@ fn main() {
     loop {
         if stop_signal.load(Ordering::Relaxed) {
             // Wait for child threads to join
-            sensor_thread.join();
-            server_thread.join();
+            sensor_thread.join().unwrap();
+            server_thread.join().unwrap();
 
             println!("Exiting main thread");
             break;

--- a/ph-sensor/src/main.rs
+++ b/ph-sensor/src/main.rs
@@ -1,27 +1,83 @@
-use std::{
-    io::{prelude::*, BufReader},
-    net::{TcpListener, TcpStream},
-};
+use std::sync::{Arc, mpsc};
+use std::sync::mpsc::{Receiver, Sender};
+use std::time::{Duration, SystemTime};
+use std::{io::{prelude::*, BufReader}, io, net::{TcpListener, TcpStream}};
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use threadpool::ThreadPool;
+use ctrlc;
 
-fn main() {
-    handle_connections();
+struct Reading {
+    timestamp: SystemTime,
+    value: f32,
 }
 
-fn handle_connections() {
+fn sensor_loop(
+    rx_reading_request: &Receiver<bool>,
+    tx_ph_value: &Sender<Reading>,
+    stop_signal: Arc<AtomicBool>,
+) {
+    println!("Sensor thread started");
+
+    // Check for new requests every second
+    let tick_duration = Duration::new(0, 1_000_000_000u32);
+
+    loop {
+        if stop_signal.load(Ordering::Relaxed) {
+            println!("Exiting sensor thread");
+            break;
+        }
+
+        match rx_reading_request.try_recv() {
+            Ok(reading_request) => {
+                tx_ph_value.send(_get_sensor_reading()).unwrap();
+            }
+            _ => {
+                std::thread::sleep(tick_duration);
+            }
+        }
+    }
+}
+
+fn _get_sensor_reading() -> Reading {
+    return Reading {
+        timestamp: SystemTime::now(),
+        value: 0.0,
+    };
+}
+
+fn handle_connections(stop_signal: Arc<AtomicBool>) {
+    println!("Server thread started");
+
+    // Check for new incoming connections each second
+    let tick_duration = Duration::new(0, 1_000_000_000u32);
+
     let listener = TcpListener::bind("[::]:24000").unwrap();
+    listener.set_nonblocking(true).expect("Unable to set listener as non-blocking");
     let pool = ThreadPool::new(4);
 
     for stream in listener.incoming() {
-        let stream = stream.unwrap();
+        match stream {
+            Ok(s) => {
+                println!("Connection established");
 
-        println!("Connection established");
-
-        pool.execute(|| {
-            handle_client(stream);
-        })
+                pool.execute(|| {
+                    handle_client(s);
+                })
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                // Check stop_signal and stop listening if true
+                if stop_signal.load(Ordering::Relaxed) {
+                    break;
+                } else {
+                    std::thread::sleep(tick_duration)
+                }
+            }
+            Err(e) => {panic!("Encountered unexpected server error: {}", e)}
+        }
     }
+    println!("Exiting server thread");
 }
 
 fn handle_client(mut stream: TcpStream) {
@@ -38,4 +94,41 @@ fn handle_client(mut stream: TcpStream) {
     let res = "HTTP/1.1 200 OK\r\n\r\n";
 
     stream.write_all(res.as_bytes()).unwrap();
+}
+
+fn main() {
+    // Channels for passing datas between socket and pH sensor threads
+    let (tx_reading_request, rx_reading_request): (Sender<bool>, Receiver<bool>) = mpsc::channel();
+    let (tx_ph_value, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
+
+    // Channel for interrupting detached threads
+    let (tx_stop, rx_stop): (Sender<bool>, Receiver<bool>) = mpsc::channel();
+    let stop_signal = Arc::new(AtomicBool::new(false));
+
+    // Spawn threads
+    let stop_signal_clone = Arc::clone(&stop_signal);
+    let sensor_thread =
+        std::thread::spawn(move || sensor_loop(&rx_reading_request, &tx_ph_value, stop_signal_clone));
+    let stop_signal_clone = Arc::clone(&stop_signal);
+    let server_thread = std::thread::spawn(move || handle_connections(stop_signal_clone));
+
+    // Handle Ctrl-C inputs
+    let stop_signal_clone = Arc::clone(&stop_signal);
+    ctrlc::set_handler(move || {
+        println!("\nCtrl-C received, stopping threads");
+        stop_signal_clone.store(true, Ordering::Relaxed);
+        return
+    }).expect("Error setting Ctrl-C handler");
+
+    // Infinite loop unless we get a stop signal
+    loop {
+        if stop_signal.load(Ordering::Relaxed) {
+            // Wait for child threads to join
+            sensor_thread.join();
+            server_thread.join();
+
+            println!("Exiting main thread");
+            break;
+        }
+    }
 }

--- a/ph-sensor/src/main.rs
+++ b/ph-sensor/src/main.rs
@@ -147,7 +147,6 @@ fn main() {
     let (tx_ph_value, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
 
     // Channel for interrupting detached threads
-    let (tx_stop, rx_stop): (Sender<bool>, Receiver<bool>) = mpsc::channel();
     let stop_signal = Arc::new(AtomicBool::new(false));
 
     // Spawn threads

--- a/ph-sensor/src/main.rs
+++ b/ph-sensor/src/main.rs
@@ -191,8 +191,8 @@ mod tests {
 
     #[test]
     fn sensor_loop_stops_on_stop_signal() {
-        let (tx_reading_request, rx_reading_request): (Sender<bool>, Receiver<bool>) = mpsc::channel();
-        let (tx_ph_value, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
+        let (_, rx_reading_request): (Sender<bool>, Receiver<bool>) = mpsc::channel();
+        let (tx_ph_value, _): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
         let stop_signal = Arc::new(AtomicBool::new(false));
         let stop_signal_clone = Arc::clone(&stop_signal);
 
@@ -229,8 +229,8 @@ mod tests {
 
     #[test]
     fn handle_connections_stops_on_stop_signal() {
-        let (tx_reading_request, rx_reading_request): (Sender<bool>, Receiver<bool>) = mpsc::channel();
-        let (tx_ph_value, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
+        let (tx_reading_request, _): (Sender<bool>, Receiver<bool>) = mpsc::channel();
+        let (_, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
         let stop_signal = Arc::new(AtomicBool::new(false));
         let stop_signal_clone = Arc::clone(&stop_signal);
 

--- a/ph-sensor/src/main.rs
+++ b/ph-sensor/src/main.rs
@@ -59,7 +59,7 @@ fn _get_sensor_reading() -> Reading {
     };
 }
 
-/// Listens for incoming TCP connections and spawns a new thread for each to handle. Non blocking
+/// Listens for incoming TCP connections and spawns a new thread for each to handle. Non-blocking
 /// and will exit when the stop_signal is true
 ///
 /// # Arguments
@@ -142,7 +142,7 @@ fn handle_client(
 }
 
 fn main() {
-    // Channels for passing datas between socket and pH sensor threads
+    // Channels for passing data between socket and pH sensor threads
     let (tx_reading_request, rx_reading_request): (Sender<bool>, Receiver<bool>) = mpsc::channel();
     let (tx_ph_value, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
 

--- a/ph-sensor/src/main.rs
+++ b/ph-sensor/src/main.rs
@@ -180,3 +180,68 @@ fn main() {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, mpsc};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc::{Receiver, Sender};
+    use std::time::Duration;
+    use crate::{handle_connections, Reading, sensor_loop};
+
+    #[test]
+    fn sensor_loop_stops_on_stop_signal() {
+        let (tx_reading_request, rx_reading_request): (Sender<bool>, Receiver<bool>) = mpsc::channel();
+        let (tx_ph_value, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
+        let stop_signal = Arc::new(AtomicBool::new(false));
+        let stop_signal_clone = Arc::clone(&stop_signal);
+
+        let sensor_loop_thread = std::thread::spawn(move || sensor_loop(&rx_reading_request, &tx_ph_value, stop_signal_clone));
+
+        println!("Sending stop signal");
+        stop_signal.store(true, Ordering::Relaxed);
+
+        // We expect the thread to stop reasonably soon after the stop signal is set
+        std::thread::sleep(Duration::new(5, 0));
+
+        assert!(sensor_loop_thread.is_finished());
+    }
+
+    #[test]
+    fn sensor_loop_requests_reading_on_channel_request() {
+        let (tx_reading_request, rx_reading_request): (Sender<bool>, Receiver<bool>) = mpsc::channel();
+        let (tx_ph_value, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
+        let stop_signal = Arc::new(AtomicBool::new(false));
+        let stop_signal_clone = Arc::clone(&stop_signal);
+
+        std::thread::spawn(move || sensor_loop(&rx_reading_request, &tx_ph_value, stop_signal_clone));
+
+        println!("Sending request");
+        tx_reading_request.send(true).expect("Error sending tx_reading_request");
+
+        println!("Expecting a result");
+        rx_ph_value.recv().unwrap();
+
+        println!("Sending stop signal");
+        stop_signal.store(true, Ordering::Relaxed);
+
+    }
+
+    #[test]
+    fn handle_connections_stops_on_stop_signal() {
+        let (tx_reading_request, rx_reading_request): (Sender<bool>, Receiver<bool>) = mpsc::channel();
+        let (tx_ph_value, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
+        let stop_signal = Arc::new(AtomicBool::new(false));
+        let stop_signal_clone = Arc::clone(&stop_signal);
+
+        let handle_connections_thread = std::thread::spawn(move || handle_connections(&tx_reading_request, &rx_ph_value, stop_signal_clone));
+
+        println!("Sending stop signal");
+        stop_signal.store(true, Ordering::Relaxed);
+
+        // We expect the thread to stop reasonably soon after the stop signal is set
+        std::thread::sleep(Duration::new(5, 0));
+
+        assert!(handle_connections_thread.is_finished());
+    }
+}

--- a/ph-sensor/src/main.rs
+++ b/ph-sensor/src/main.rs
@@ -65,6 +65,7 @@ fn handle_connections(
     listener
         .set_nonblocking(true)
         .expect("Unable to set listener as non-blocking");
+
     for stream in listener.incoming() {
         match stream {
             Ok(s) => {
@@ -86,6 +87,7 @@ fn handle_connections(
             }
         }
     }
+
     println!("Exiting server thread");
 }
 

--- a/ph-sensor/src/main.rs
+++ b/ph-sensor/src/main.rs
@@ -17,6 +17,14 @@ struct Reading {
     value: f32,
 }
 
+/// Awaits for a request of a new sensor reading and returns a single Reading instance back. Will
+/// exit when stop_signal is set to true
+///
+/// # Arguments
+///
+/// * `rx_reading_request`: Channel for listening for a sensor reading request on
+/// * `tx_ph_value`: Channel to send an updated Reading instance through
+/// * `stop_signal`: Set to true if it should stop listening for connections
 fn sensor_loop(
     rx_reading_request: &Receiver<bool>,
     tx_ph_value: &Sender<Reading>,
@@ -51,6 +59,14 @@ fn _get_sensor_reading() -> Reading {
     };
 }
 
+/// Listens for incoming TCP connections and spawns a new thread for each to handle. Non blocking
+/// and will exit when the stop_signal is true
+///
+/// # Arguments
+///
+/// * `tx_reading_request`: Channel for sending a request for a new Reading
+/// * `rx_ph_value`: Channel for Reading response
+/// * `stop_signal`: Set to true if it should stop listening for connections
 fn handle_connections(
     tx_reading_request: &Sender<bool>,
     rx_ph_value: &Receiver<Reading>,
@@ -91,6 +107,13 @@ fn handle_connections(
     println!("Exiting server thread");
 }
 
+/// Handles a single TCP connection
+///
+/// # Arguments
+///
+/// * `stream`: Single TcpStream to handle
+/// * `tx_reading_request`: Channel to send a sensor reading request through
+/// * `rx_ph_value`: Channel to receive an updated sensor Reading from
 fn handle_client(
     mut stream: TcpStream,
     tx_reading_request: &Sender<bool>,

--- a/ph-sensor/src/main.rs
+++ b/ph-sensor/src/main.rs
@@ -1,145 +1,13 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{mpsc, Arc};
-use std::time::{Duration, SystemTime};
-use std::{
-    io,
-    io::{prelude::*, BufReader},
-    net::{TcpListener, TcpStream},
-};
 
 use ctrlc;
-use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
-struct Reading {
-    timestamp: SystemTime,
-    value: f32,
-}
+use sensor::Reading;
 
-/// Awaits for a request of a new sensor reading and returns a single Reading instance back. Will
-/// exit when stop_signal is set to true
-///
-/// # Arguments
-///
-/// * `rx_reading_request`: Channel for listening for a sensor reading request on
-/// * `tx_ph_value`: Channel to send an updated Reading instance through
-/// * `stop_signal`: Set to true if it should stop listening for connections
-fn sensor_loop(
-    rx_reading_request: &Receiver<bool>,
-    tx_ph_value: &Sender<Reading>,
-    stop_signal: Arc<AtomicBool>,
-) {
-    println!("Sensor thread started");
-
-    // Check for new requests every second
-    let tick_duration = Duration::new(0, 1_000_000_000u32);
-
-    loop {
-        if stop_signal.load(Ordering::Relaxed) {
-            println!("Exiting sensor thread");
-            break;
-        }
-
-        match rx_reading_request.try_recv() {
-            Ok(_) => {
-                tx_ph_value.send(_get_sensor_reading()).unwrap();
-            }
-            _ => {
-                std::thread::sleep(tick_duration);
-            }
-        }
-    }
-}
-
-fn _get_sensor_reading() -> Reading {
-    return Reading {
-        timestamp: SystemTime::now(),
-        value: 7.0,
-    };
-}
-
-/// Listens for incoming TCP connections and spawns a new thread for each to handle. Non-blocking
-/// and will exit when the stop_signal is true
-///
-/// # Arguments
-///
-/// * `tx_reading_request`: Channel for sending a request for a new Reading
-/// * `rx_ph_value`: Channel for Reading response
-/// * `stop_signal`: Set to true if it should stop listening for connections
-fn handle_connections(
-    tx_reading_request: &Sender<bool>,
-    rx_ph_value: &Receiver<Reading>,
-    stop_signal: Arc<AtomicBool>,
-) {
-    println!("Server thread started");
-
-    // Check for new incoming connections each second
-    let tick_duration = Duration::new(0, 1_000_000_000u32);
-
-    let listener = TcpListener::bind("[::]:24000").unwrap();
-    listener
-        .set_nonblocking(true)
-        .expect("Unable to set listener as non-blocking");
-
-    for stream in listener.incoming() {
-        match stream {
-            Ok(s) => {
-                println!("Connection established");
-
-                handle_client(s, &tx_reading_request, &rx_ph_value);
-            }
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-                // Check stop_signal and stop listening if true
-                if stop_signal.load(Ordering::Relaxed) {
-                    drop(listener);
-                    break;
-                } else {
-                    std::thread::sleep(tick_duration)
-                }
-            }
-            Err(e) => {
-                panic!("Encountered unexpected server error: {}", e)
-            }
-        }
-    }
-
-    println!("Exiting server thread");
-}
-
-/// Handles a single TCP connection
-///
-/// # Arguments
-///
-/// * `stream`: Single TcpStream to handle
-/// * `tx_reading_request`: Channel to send a sensor reading request through
-/// * `rx_ph_value`: Channel to receive an updated sensor Reading from
-fn handle_client(
-    mut stream: TcpStream,
-    tx_reading_request: &Sender<bool>,
-    rx_ph_value: &Receiver<Reading>,
-) {
-    let buf_reader = BufReader::new(&mut stream);
-
-    let http_request: Vec<_> = buf_reader
-        .lines()
-        .map(|result| result.unwrap())
-        .take_while(|line| !line.is_empty())
-        .collect();
-
-    println!("Request: {:#?}", http_request);
-
-    // Request an updated reading from pH sensor thread
-    tx_reading_request.send(true).unwrap();
-
-    // Format to JSON
-    let reading = rx_ph_value.recv().unwrap();
-    let reading_json = serde_json::to_string(&reading).unwrap();
-
-    // Send response back and close connection
-    let res = "HTTP/1.1 200 OK\r\n\r\n".to_owned() + &*reading_json;
-    stream.write_all(res.as_bytes()).unwrap();
-}
+mod sensor;
+mod server;
 
 fn main() {
     // Channels for passing data between socket and pH sensor threads
@@ -152,11 +20,11 @@ fn main() {
     // Spawn threads
     let stop_signal_clone = Arc::clone(&stop_signal);
     let sensor_thread = std::thread::spawn(move || {
-        sensor_loop(&rx_reading_request, &tx_ph_value, stop_signal_clone)
+        sensor::sensor_loop(&rx_reading_request, &tx_ph_value, stop_signal_clone)
     });
     let stop_signal_clone = Arc::clone(&stop_signal);
     let server_thread = std::thread::spawn(move || {
-        handle_connections(&tx_reading_request, &rx_ph_value, stop_signal_clone)
+        server::handle_connections(&tx_reading_request, &rx_ph_value, stop_signal_clone)
     });
 
     // Handle Ctrl-C inputs
@@ -178,79 +46,5 @@ fn main() {
             println!("Exiting main thread");
             break;
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc::{Receiver, Sender};
-    use std::sync::{mpsc, Arc};
-    use std::time::Duration;
-
-    use crate::{handle_connections, sensor_loop, Reading};
-
-    #[test]
-    fn sensor_loop_stops_on_stop_signal() {
-        let (_, rx_reading_request): (Sender<bool>, Receiver<bool>) = mpsc::channel();
-        let (tx_ph_value, _): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
-        let stop_signal = Arc::new(AtomicBool::new(false));
-        let stop_signal_clone = Arc::clone(&stop_signal);
-
-        let sensor_loop_thread = std::thread::spawn(move || {
-            sensor_loop(&rx_reading_request, &tx_ph_value, stop_signal_clone)
-        });
-
-        println!("Sending stop signal");
-        stop_signal.store(true, Ordering::Relaxed);
-
-        // We expect the thread to stop reasonably soon after the stop signal is set
-        std::thread::sleep(Duration::new(5, 0));
-
-        assert!(sensor_loop_thread.is_finished());
-    }
-
-    #[test]
-    fn sensor_loop_requests_reading_on_channel_request() {
-        let (tx_reading_request, rx_reading_request): (Sender<bool>, Receiver<bool>) =
-            mpsc::channel();
-        let (tx_ph_value, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
-        let stop_signal = Arc::new(AtomicBool::new(false));
-        let stop_signal_clone = Arc::clone(&stop_signal);
-
-        std::thread::spawn(move || {
-            sensor_loop(&rx_reading_request, &tx_ph_value, stop_signal_clone)
-        });
-
-        println!("Sending request");
-        tx_reading_request
-            .send(true)
-            .expect("Error sending tx_reading_request");
-
-        println!("Expecting a result");
-        rx_ph_value.recv().unwrap();
-
-        println!("Sending stop signal");
-        stop_signal.store(true, Ordering::Relaxed);
-    }
-
-    #[test]
-    fn handle_connections_stops_on_stop_signal() {
-        let (tx_reading_request, _): (Sender<bool>, Receiver<bool>) = mpsc::channel();
-        let (_, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
-        let stop_signal = Arc::new(AtomicBool::new(false));
-        let stop_signal_clone = Arc::clone(&stop_signal);
-
-        let handle_connections_thread = std::thread::spawn(move || {
-            handle_connections(&tx_reading_request, &rx_ph_value, stop_signal_clone)
-        });
-
-        println!("Sending stop signal");
-        stop_signal.store(true, Ordering::Relaxed);
-
-        // We expect the thread to stop reasonably soon after the stop signal is set
-        std::thread::sleep(Duration::new(5, 0));
-
-        assert!(handle_connections_thread.is_finished());
     }
 }

--- a/ph-sensor/src/sensor.rs
+++ b/ph-sensor/src/sensor.rs
@@ -85,7 +85,7 @@ fn _add_reading_to_reading_log() {
     file.read_to_string(&mut contents)
         .expect("Unable to read log contents");
 
-    let mut old_data = if contents.is_empty() {
+    let mut contents = if contents.is_empty() {
         ReadingLog {
             readings: Vec::new(),
         }
@@ -93,14 +93,10 @@ fn _add_reading_to_reading_log() {
         serde_json::from_str(&contents).expect("Failed to parse old contents")
     };
 
-    // Test add new value
-    old_data.readings.push(Reading {
-        timestamp: SystemTime::now(),
-        value: 6.5,
-    });
+    contents.readings.push(_get_sensor_reading());
 
     let serialized_data =
-        serde_json::to_string_pretty(&old_data).expect("Unable to serialize new data");
+        serde_json::to_string_pretty(&contents).expect("Unable to serialize new data");
 
     file.seek(std::io::SeekFrom::Start(0))
         .expect("Unable to seek to beginning");

--- a/ph-sensor/src/sensor.rs
+++ b/ph-sensor/src/sensor.rs
@@ -1,0 +1,108 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, Sender};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct Reading {
+    timestamp: SystemTime,
+    value: f32,
+}
+
+/// Awaits for a request of a new sensor reading and returns a single Reading instance back. Will
+/// exit when stop_signal is set to true
+///
+/// # Arguments
+///
+/// * `rx_reading_request`: Channel for listening for a sensor reading request on
+/// * `tx_ph_value`: Channel to send an updated Reading instance through
+/// * `stop_signal`: Set to true if it should stop listening for connections
+pub fn sensor_loop(
+    rx_reading_request: &Receiver<bool>,
+    tx_ph_value: &Sender<Reading>,
+    stop_signal: Arc<AtomicBool>,
+) {
+    println!("Sensor thread started");
+
+    // Check for new requests every second
+    let tick_duration = Duration::new(0, 1_000_000_000u32);
+
+    loop {
+        if stop_signal.load(Ordering::Relaxed) {
+            println!("Exiting sensor thread");
+            break;
+        }
+
+        match rx_reading_request.try_recv() {
+            Ok(_) => {
+                tx_ph_value.send(_get_sensor_reading()).unwrap();
+            }
+            _ => {
+                std::thread::sleep(tick_duration);
+            }
+        }
+    }
+}
+
+fn _get_sensor_reading() -> Reading {
+    return Reading {
+        timestamp: SystemTime::now(),
+        value: 7.0,
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc::{Receiver, Sender};
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    use crate::sensor::{sensor_loop, Reading};
+
+    #[test]
+    fn sensor_loop_stops_on_stop_signal() {
+        let (_, rx_reading_request): (Sender<bool>, Receiver<bool>) = mpsc::channel();
+        let (tx_ph_value, _): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
+        let stop_signal = Arc::new(AtomicBool::new(false));
+        let stop_signal_clone = Arc::clone(&stop_signal);
+
+        let sensor_loop_thread = std::thread::spawn(move || {
+            sensor_loop(&rx_reading_request, &tx_ph_value, stop_signal_clone)
+        });
+
+        println!("Sending stop signal");
+        stop_signal.store(true, Ordering::Relaxed);
+
+        // We expect the thread to stop reasonably soon after the stop signal is set
+        std::thread::sleep(Duration::new(5, 0));
+
+        assert!(sensor_loop_thread.is_finished());
+    }
+
+    #[test]
+    fn sensor_loop_requests_reading_on_channel_request() {
+        let (tx_reading_request, rx_reading_request): (Sender<bool>, Receiver<bool>) =
+            mpsc::channel();
+        let (tx_ph_value, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
+        let stop_signal = Arc::new(AtomicBool::new(false));
+        let stop_signal_clone = Arc::clone(&stop_signal);
+
+        std::thread::spawn(move || {
+            sensor_loop(&rx_reading_request, &tx_ph_value, stop_signal_clone)
+        });
+
+        println!("Sending request");
+        tx_reading_request
+            .send(true)
+            .expect("Error sending tx_reading_request");
+
+        println!("Expecting a result");
+        rx_ph_value.recv().unwrap();
+
+        println!("Sending stop signal");
+        stop_signal.store(true, Ordering::Relaxed);
+    }
+}

--- a/ph-sensor/src/sensor.rs
+++ b/ph-sensor/src/sensor.rs
@@ -1,7 +1,9 @@
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +11,11 @@ use serde::{Deserialize, Serialize};
 pub struct Reading {
     timestamp: SystemTime,
     value: f32,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ReadingLog {
+    readings: Vec<Reading>,
 }
 
 /// Awaits for a request of a new sensor reading and returns a single Reading instance back. Will
@@ -28,6 +35,7 @@ pub fn sensor_loop(
 
     // Check for new requests every second
     let tick_duration = Duration::new(0, 1_000_000_000u32);
+    let mut next_automated_reading_time = SystemTime::now();
 
     loop {
         if stop_signal.load(Ordering::Relaxed) {
@@ -41,9 +49,66 @@ pub fn sensor_loop(
             }
             _ => {
                 std::thread::sleep(tick_duration);
+
+                if next_automated_reading_time < SystemTime::now() {
+                    let current_time = SystemTime::now();
+
+                    // Set next automated reading to be next midnight
+                    let duration_since_epoch = current_time
+                        .duration_since(UNIX_EPOCH)
+                        .expect("Failed to get duration since epoch");
+                    let seconds_since_midnight = duration_since_epoch.as_secs() % (24 * 60 * 60);
+                    let seconds_until_midnight = (24 * 60 * 60) - seconds_since_midnight;
+                    next_automated_reading_time =
+                        current_time + Duration::from_secs(seconds_until_midnight);
+
+                    _add_reading_to_reading_log();
+                }
             }
         }
     }
+}
+
+fn _add_reading_to_reading_log() {
+    println!("Adding reading");
+    let log_path = "../../reading_log";
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(log_path)
+        .expect("Unable to open log");
+
+    let mut contents = String::new();
+
+    file.read_to_string(&mut contents)
+        .expect("Unable to read log contents");
+
+    let mut old_data = if contents.is_empty() {
+        ReadingLog {
+            readings: Vec::new(),
+        }
+    } else {
+        serde_json::from_str(&contents).expect("Failed to parse old contents")
+    };
+
+    // Test add new value
+    old_data.readings.push(Reading {
+        timestamp: SystemTime::now(),
+        value: 6.5,
+    });
+
+    let serialized_data =
+        serde_json::to_string_pretty(&old_data).expect("Unable to serialize new data");
+
+    file.seek(std::io::SeekFrom::Start(0))
+        .expect("Unable to seek to beginning");
+    file.set_len(0).expect("Unable to truncate file");
+    file.write_all(serialized_data.as_bytes())
+        .expect("Unable to write to file");
+
+    println!("Log updated");
 }
 
 fn _get_sensor_reading() -> Reading {

--- a/ph-sensor/src/sensor.rs
+++ b/ph-sensor/src/sensor.rs
@@ -47,10 +47,10 @@ pub fn sensor_loop(
 }
 
 fn _get_sensor_reading() -> Reading {
-    return Reading {
+    Reading {
         timestamp: SystemTime::now(),
         value: 7.0,
-    };
+    }
 }
 
 #[cfg(test)]

--- a/ph-sensor/src/server.rs
+++ b/ph-sensor/src/server.rs
@@ -43,9 +43,9 @@ pub fn handle_connections(
                 if stop_signal.load(Ordering::Relaxed) {
                     drop(listener);
                     break;
-                } else {
-                    std::thread::sleep(tick_duration)
                 }
+
+                std::thread::sleep(tick_duration)
             }
             Err(e) => {
                 panic!("Encountered unexpected server error: {}", e)

--- a/ph-sensor/src/server.rs
+++ b/ph-sensor/src/server.rs
@@ -1,0 +1,122 @@
+use std::io;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, Sender};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::sensor::Reading;
+
+/// Listens for incoming TCP connections and spawns a new thread for each to handle. Non-blocking
+/// and will exit when the stop_signal is true
+///
+/// # Arguments
+///
+/// * `tx_reading_request`: Channel for sending a request for a new Reading
+/// * `rx_ph_value`: Channel for Reading response
+/// * `stop_signal`: Set to true if it should stop listening for connections
+pub fn handle_connections(
+    tx_reading_request: &Sender<bool>,
+    rx_ph_value: &Receiver<Reading>,
+    stop_signal: Arc<AtomicBool>,
+) {
+    println!("Server thread started");
+
+    // Check for new incoming connections each second
+    let tick_duration = Duration::new(0, 1_000_000_000u32);
+
+    let listener = TcpListener::bind("[::]:24000").unwrap();
+    listener
+        .set_nonblocking(true)
+        .expect("Unable to set listener as non-blocking");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(s) => {
+                println!("Connection established");
+
+                handle_client(s, &tx_reading_request, &rx_ph_value);
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                // Check stop_signal and stop listening if true
+                if stop_signal.load(Ordering::Relaxed) {
+                    drop(listener);
+                    break;
+                } else {
+                    std::thread::sleep(tick_duration)
+                }
+            }
+            Err(e) => {
+                panic!("Encountered unexpected server error: {}", e)
+            }
+        }
+    }
+
+    println!("Exiting server thread");
+}
+
+/// Handles a single TCP connection
+///
+/// # Arguments
+///
+/// * `stream`: Single TcpStream to handle
+/// * `tx_reading_request`: Channel to send a sensor reading request through
+/// * `rx_ph_value`: Channel to receive an updated sensor Reading from
+fn handle_client(
+    mut stream: TcpStream,
+    tx_reading_request: &Sender<bool>,
+    rx_ph_value: &Receiver<Reading>,
+) {
+    let buf_reader = BufReader::new(&mut stream);
+
+    let http_request: Vec<_> = buf_reader
+        .lines()
+        .map(|result| result.unwrap())
+        .take_while(|line| !line.is_empty())
+        .collect();
+
+    println!("Request: {:#?}", http_request);
+
+    // Request an updated reading from pH sensor thread
+    tx_reading_request.send(true).unwrap();
+
+    // Format to JSON
+    let reading = rx_ph_value.recv().unwrap();
+    let reading_json = serde_json::to_string(&reading).unwrap();
+
+    // Send response back and close connection
+    let res = "HTTP/1.1 200 OK\r\n\r\n".to_owned() + &*reading_json;
+    stream.write_all(res.as_bytes()).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc::{Receiver, Sender};
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    use crate::sensor::Reading;
+    use crate::server::handle_connections;
+
+    #[test]
+    fn handle_connections_stops_on_stop_signal() {
+        let (tx_reading_request, _): (Sender<bool>, Receiver<bool>) = mpsc::channel();
+        let (_, rx_ph_value): (Sender<Reading>, Receiver<Reading>) = mpsc::channel();
+        let stop_signal = Arc::new(AtomicBool::new(false));
+        let stop_signal_clone = Arc::clone(&stop_signal);
+
+        let handle_connections_thread = std::thread::spawn(move || {
+            handle_connections(&tx_reading_request, &rx_ph_value, stop_signal_clone)
+        });
+
+        println!("Sending stop signal");
+        stop_signal.store(true, Ordering::Relaxed);
+
+        // We expect the thread to stop reasonably soon after the stop signal is set
+        std::thread::sleep(Duration::new(5, 0));
+
+        assert!(handle_connections_thread.is_finished());
+    }
+}


### PR DESCRIPTION
- Listens for incoming HTTP requests on port 24000 and responds with JSON
- Splits sensor and server loops to two threads
- Adds graceful exiting by listening for Ctrl C SIGINT
- Adds unit tests to ensure two main detached threads, sensor and server, are killed within 5 seconds of SIGINT
- Keeps a log of readings that's automatically added to

Closes #15 